### PR TITLE
Add script for extracting transcript text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ data/raw/manifest.csv
 # Keep processed dir structure but not outputs
 data/processed/**
 !data/processed/.gitkeep
+# Plain-text transcript exports
+data/transcript_text/**
+!data/transcript_text/.gitkeep

--- a/scripts/extract_transcript_text.py
+++ b/scripts/extract_transcript_text.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Convert a transcript JSON file into plain text."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_OUT_DIR = Path("data") / "transcript_text"
+
+
+def extract_text(json_file: Path, out_dir: Path | None = None) -> Path:
+    """Extract transcript text from *json_file* into *out_dir*.
+
+    Returns the path to the written text file.
+    Raises ValueError if the JSON is malformed or missing ``text``.
+    """
+    out_dir = out_dir or DEFAULT_OUT_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - message tested via CLI
+        raise ValueError(f"Malformed JSON: {exc}") from exc
+
+    text = data.get("text")
+    if not isinstance(text, str):
+        raise ValueError("Missing 'text' field in transcript JSON")
+
+    out_file = out_dir / (json_file.stem + ".txt")
+    out_file.write_text(text, encoding="utf-8")
+    return out_file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract transcript text from a JSON file")
+    parser.add_argument("json_file", type=Path, help="Path to transcript JSON file")
+    args = parser.parse_args()
+
+    try:
+        out_path = extract_text(args.json_file)
+    except Exception as exc:  # pragma: no cover - exercised via CLI tests
+        parser.exit(1, f"Error: {exc}\n")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_extract_transcript_text.py
+++ b/tests/test_extract_transcript_text.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_script(json_path: Path, cwd: Path) -> subprocess.CompletedProcess:
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "scripts" / "extract_transcript_text.py"
+    return subprocess.run(
+        [sys.executable, str(script), str(json_path)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_extract_transcript_text_success(tmp_path: Path) -> None:
+    json_file = tmp_path / "sample.json"
+    json_file.write_text(json.dumps({"text": "hello world"}))
+
+    result = run_script(json_file, tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    out_file = tmp_path / "data" / "transcript_text" / "sample.txt"
+    assert out_file.read_text() == "hello world"
+
+
+def test_extract_transcript_text_missing_text(tmp_path: Path) -> None:
+    json_file = tmp_path / "missing.json"
+    json_file.write_text(json.dumps({"nope": "data"}))
+
+    result = run_script(json_file, tmp_path)
+    assert result.returncode != 0
+    assert "Missing 'text' field" in result.stderr
+
+
+def test_extract_transcript_text_malformed_json(tmp_path: Path) -> None:
+    json_file = tmp_path / "bad.json"
+    json_file.write_text("{not json}")
+
+    result = run_script(json_file, tmp_path)
+    assert result.returncode != 0
+    assert "Malformed JSON" in result.stderr


### PR DESCRIPTION
## Summary
- add `scripts/extract_transcript_text.py` to convert transcript JSON files into plain-text `.txt`
- ignore `data/transcript_text` outputs and provide gitkeep
- add tests covering success and error cases

## Testing
- `ruff check scripts/extract_transcript_text.py tests/test_extract_transcript_text.py`
- `ruff format scripts/extract_transcript_text.py tests/test_extract_transcript_text.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b98f3f41f88330a362e4bd6fefa8da