### PR TITLE
Document .env usage for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ export OPENAI_API_KEY=your_key
 python summarize.py --config config/summarizer.yaml
 ```
 
+Alternatively, place a `.env` file in the project root (alongside this README) with the following structure:
+
+```
+OPENAI_API_KEY=your_key
+```
+
+The scripts automatically load environment variables from `.env` if present, so you can omit the `export` step when using this approach.
+
 Summary files are written to `data/processed/`.
 
 ### 3. Optional: extract plain transcript text

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Alternatively, place a `.env` file in the project root (alongside this README) w
 
 ```text
 OPENAI_API_KEY=your_key
+# Optional overrides (otherwise, summarizer.py reads config/summarizer.yaml)
+# MODEL=gpt-40-mini
+# TEMPERATURE=0.2
 ```
 
 The scripts automatically load environment variables from `.env` if present, so you can omit the `export` step when using this approach.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python summarize.py --config config/summarizer.yaml
 
 Alternatively, place a `.env` file in the project root (alongside this README) with the following structure:
 
-```
+```text
 OPENAI_API_KEY=your_key
 ```
 
@@ -80,5 +80,3 @@ pytest
 ## License
 
 MIT
-
-


### PR DESCRIPTION
## Summary
- explain that users can optionally load their OpenAI API key from a `.env` file
- document the expected `.env` structure and note it belongs in the project root

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7cb87ffa0833094b0e1b56b96a640